### PR TITLE
Add default configure URL for all configures

### DIFF
--- a/access/course.py
+++ b/access/course.py
@@ -22,7 +22,8 @@ LOGGER = logging.getLogger('main')
 
 class ConfigureOptions(PydanticModel):
     files: Dict[str,str] = {}
-    url: str
+    # ellipsis (...) makes the field required in the case that a default url isn't specified
+    url: str = settings.DEFAULT_GRADER_URL or ... # type: ignore
 
 
 class ExerciseConfig(PydanticModel):
@@ -211,9 +212,6 @@ class Exercise(Item):
         # DEPRECATED: default configure settings
         # this is for backwards compatibility and should be removed in the future
         if not self.configure and self._config_obj and settings.DEFAULT_GRADER_URL is not None:
-            configure = {
-                "url": settings.DEFAULT_GRADER_URL,
-            }
             files = {}
             for lang_data in self._config_obj.data.values():
                 mount = lang_data.get("container", {}).get("mount")
@@ -252,9 +250,7 @@ class Exercise(Item):
                         else:
                             files[path] = path
 
-            configure["files"] = files
-
-            self.configure = ConfigureOptions.parse_obj(configure)
+            self.configure = ConfigureOptions.parse_obj({"files": files})
 
 
     @root_validator(allow_reuse=True, skip_on_failure=True)


### PR DESCRIPTION
# Description

**What?**

Adds default configure URL for all ConfigureOptions.

**Why?**

See #10.

**How?**

Add default value to the URL field in the ConfigureOptions model.

Fixes #10.

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [X] Manual testing.

Tested that the configure options are loaded correctly when it is or isn't given in the .yaml files. Also did the same for when the default URL isn't specified.

**Did you test the changes in**

- [ ] Chrome
- [ ] Firefox
- [X] This pull request cannot be tested in the browser.

# Programming style

- [X] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [X] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
