### PR TITLE
Add unprotected_paths validation

### DIFF
--- a/util/files.py
+++ b/util/files.py
@@ -46,9 +46,23 @@ def rm_path(path: Union[str, Path]) -> None:
         path.unlink()
 
 
-def is_subpath(child: str, parent: str):
+def is_subpath(child: PathLike, parent: Optional[PathLike] = None) -> bool:
+    """
+    If parent is not None, returns whether child is a subpath of (contained in)
+    parent.
+    If parent is None, check that child is a relative subpath i.e.
+    is_subpath(Path(<location>, child), <location>) is True for every <location>.
+    """
+    child = os.path.normpath(child)
+
+    if parent is None:
+        return not os.path.isabs(child) and not child.startswith("../")
+
+    parent = os.path.normpath(parent)
+
     if child == parent:
         return True
+
     return len(child) > len(parent) and child[len(parent)] == "/" and child.startswith(parent)
 
 


### PR DESCRIPTION


# Description

**What?**

Only files under the static directory can be served, so only they can be unprotected

**Why?**

Obscure errors when invalid paths are given.

**How?**

Check that the paths are subpaths in the pydantic validator.

Fixes #14


# Testing

**Remember to add or update unit tests for new features and changes.**

* How to [test your changes in A-plus](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations)
* How to [test accessibility](https://wiki.aalto.fi/display/EDIT/How+to+check+the+accessibility+of+pull+requests)


**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [X] Manual testing.

Tested that correct paths pass and incorrect paths don't.

**Did you test the changes in**

- [ ] Chrome
- [ ] Firefox
- [X] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [X] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [X] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
