### PR TITLE
Add button to scroll to the bottom of update log

### DIFF
--- a/builder/templates/builder/updates.html
+++ b/builder/templates/builder/updates.html
@@ -52,6 +52,7 @@
 </p>
 <table class="table table-bordered fitted">
 	<tr>
+		<th></th>
 		<th>Request IP</th>
 		<th>Commit hash</th>
 		<th>Status</th>
@@ -60,6 +61,7 @@
 	</tr>
 	{% for update in updates %}
 		<tr>
+			<td><button class="scroll-button">Scroll to end</button></td>
 			<td>{{ update.request_ip }}</td>
 			<td>{{ update.commit_hash|default:"-" }}</td>
 			<td>{{ update.status }}</td>
@@ -68,7 +70,7 @@
 		</tr>
 		{% if update.log %}
 			<tr>
-				<td colspan="5">
+				<td colspan="6">
 					<pre>{{ update.log }}</pre>
 				</td>
 			</tr>
@@ -80,4 +82,7 @@
 <style>
 	{% include "builder/updates.css" %}
 </style>
+<script type="text/javascript">
+	{% include "builder/updates.js" %}
+</script>
 {% endblock %}

--- a/builder/templates/builder/updates.js
+++ b/builder/templates/builder/updates.js
@@ -1,0 +1,10 @@
+function scrollToBottomOf(element) {
+    const rect = element.getBoundingClientRect();
+    window.scroll(0, window.scrollY + rect.bottom - window.innerHeight);
+}
+
+const buttons = document.querySelectorAll("button.scroll-button");
+buttons.forEach((b) => b.onclick = (event) => {
+    const log_element = event.target.parentElement.parentElement.nextElementSibling;
+    scrollToBottomOf(log_element);
+});


### PR DESCRIPTION
# Description

**What?**

Each update log entry now has a button to scroll to the bottom of the log. 

**Why?**

The error message is typically at the end, so this is useful.

**How?**

Button to HTML + javascript to do the scrolling.

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [X] Manual testing.

Tested that the buttons work in browser.

**Did you test the changes in**

- [X] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.
