### PR TITLE
Add support for multiarch container images (amd64/arm64)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM apluslms/service-base:django-1.17
+FROM --platform=$TARGETPLATFORM apluslms/service-base:django-1.18
 
 # Set container related configuration via environment variables.
 ENV CONTAINER_TYPE="gitmanager" \
@@ -7,6 +7,8 @@ ENV CONTAINER_TYPE="gitmanager" \
     REDIS_HOST="redis" \
     HUEY_IMMEDIATE="true"
 
+ARG TARGETPLATFORM
+
 RUN : \
  && apt_install \
       apt-transport-https \
@@ -14,8 +16,9 @@ RUN : \
       # temp
       gnupg curl \
   # install docker-ce
+ && if [ "$TARGETPLATFORM" = "linux/amd64" ] ; then ARCH=amd64 ; elif [ "$TARGETPLATFORM" = "linux/arm64" ] ; then ARCH=arm64 ; else exit 1 ; fi \
  && curl -LSs https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg >/dev/null 2>&1 \
- && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian bullseye stable" > /etc/apt/sources.list.d/docker.list \
+ && echo "deb [arch=$ARCH signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian bullseye stable" > /etc/apt/sources.list.d/docker.list \
  && apt_install docker-ce \
 \
   # create user

--- a/docker/Dockerfile.huey
+++ b/docker/Dockerfile.huey
@@ -1,5 +1,5 @@
 ARG FULL_TAG=latest
-FROM apluslms/run-gitmanager:$FULL_TAG
+FROM --platform=$TARGETPLATFORM apluslms/run-gitmanager:$FULL_TAG
 
 ENV CONTAINER_TYPE="gitmanagerhuey" \
     GITMANAGER_LOCAL_SETTINGS="/srv/gitmanagerhuey-cont-settings.py" \

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+docker run --privileged --rm tonistiigi/binfmt --install all
+
+docker buildx create --use default
+
 ver="$DOCKER_TAG"
 
 # Docker Hub builds seem to break if the absolute file path $DOCKERFILE_PATH
@@ -21,12 +25,16 @@ for layer in "" "huey"; do
     echo "### >  -t $DOCKER_REPO:$tag ."
     echo "### PWD=$(pwd)"
 
-    docker build --build-arg "FULL_TAG=$ver" \
-                 -t "$DOCKER_REPO":"$tag" -f "$file" ..
+    docker buildx build \
+    --push \
+    --platform linux/amd64,linux/arm64 \
+    --build-arg "FULL_TAG=$ver" \
+    -t "$DOCKER_REPO":"$tag" \
+    -f "$file" ..
+
     res=$?
     if [ $res -ne 0 ]; then
         echo "Building layer '$layer' returned $res" >&2
         exit $res
     fi
 done
-

--- a/docker/hooks/push
+++ b/docker/hooks/push
@@ -1,16 +1,3 @@
 #!/bin/sh
 
-ver=${DOCKER_TAG##*-}
-if [ "$ver" -a "$ver" = "$DOCKER_TAG" ]; then
-    ver="$DOCKER_TAG"
-fi
-
-for layer in "" "huey"; do
-    if [ "$layer" ]; then
-        tag="${layer}-${ver}"
-    else
-        tag="$ver"
-    fi
-    docker push "$DOCKER_REPO":"$tag"
-done
-
+# This hook is empty because the images were pushed to the registry in the build hook


### PR DESCRIPTION
# Description

**What?**

Add support for automatic building of multi-architecture container images (amd64/arm64).

This PR requires that service-base has multi-architecture support first.

**Why?**

Container images built with support for the ARM architecture perform much better on Apple Silicon laptops.

**How?**

A custom build hook is used to build the image for amd64 and arm64.
The image is pushed to Docker Hub in the build hook.

Links about the docker buildx plugin for future reference:
- https://github.com/docker/buildx
- https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/
- https://hub.docker.com/r/tonistiigi/binfmt

# Testing

I tested that Docker Hub Automated Builds work as expected.