### PR TITLE
Add support to a new reveal rule

### DIFF
--- a/access/course.py
+++ b/access/course.py
@@ -67,7 +67,7 @@ class ConfigureOptions(PydanticModel):
 
 
 class RevealRuleOptions(PydanticModel):
-    trigger: Literal["immediate", "manual", "time", "deadline", "deadline_all", "completion"]
+    trigger: Literal["immediate", "manual", "time", "deadline", "deadline_all", "deadline_or_full_points", "completion"]
     time: NotRequired[AnyDate]
     delay_minutes: NotRequired[NonNegativeInt]
 


### PR DESCRIPTION
# Description

**What?**

Adds support to a new reveal rule, check https://github.com/apluslms/a-plus/pull/1220.

**Why?**

The reveal rule should be possible to be configured in conf.py etc.

**How?**

Adds the reveal rule name as a possible trigger option.
Should be merged together with https://github.com/apluslms/a-plus-rst-tools/pull/167.

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Set the reveal_model_solutions variable in O1's conf.py. Ran gitmanager locally. Checked in aplus course content settings that the model solution reveal rule option was updated to exercises.

**Did you test the changes in**

- [ ] Chrome
- [x] Firefox
- [ ] This pull request cannot be tested in the browser.

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
