### PR TITLE
Add RetryingMemcacheClient class

### DIFF
--- a/gitmanager/settings.py
+++ b/gitmanager/settings.py
@@ -169,6 +169,13 @@ DATABASES = {
 #SESSION_ENGINE = 'django.contrib.sessions.backends.cached_db'
 ##########################################################################
 
+# pymemcache's RetryingClient configuration options
+# https://pymemcache.readthedocs.io/en/latest/apidoc/pymemcache.client.retrying.html
+RETRYING_MEMCACHE_CLIENT_OPTIONS = {
+    'attempts': 10,
+    'retry_delay': 3,
+}
+
 # Internationalization
 # https://docs.djangoproject.com/en/1.6/topics/i18n/
 LANGUAGE_CODE = 'en-us'

--- a/util/retrying_memcache_client.py
+++ b/util/retrying_memcache_client.py
@@ -1,0 +1,11 @@
+from pymemcache.client import retrying, hash
+from django.core.cache.backends.memcached import PyMemcacheCache
+from django.conf import settings
+
+class RetryingMemcacheClient(PyMemcacheCache):
+    def __init__(self, server, params):
+        super().__init__(server, params)
+        self._cache = retrying.RetryingClient(
+            hash.HashClient(self.client_servers, **self._options),
+            **settings.RETRYING_MEMCACHE_CLIENT_OPTIONS
+        )


### PR DESCRIPTION
# Description

Add a RetryingMemcacheClient class. Using this will allow momentary network errors while fetching course configurations to not stop and fail the whole course build process.

**Why?**

Every now and then, we've encountered MemcacheUnexpectedCloseErrors while building courses. While we're not sure what's causing these, currently this causes the whole course build process to stop and fail, and either a new push to the repository or manually triggering the course build via gitmanager's UI is required to retry. Hopefully giving the client a chance to retry in case of momentary network failures or such should these cases, or at the very least reduce their number.

Fixes #52 

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [X] Manual testing.

Used the following docker-compose file and slightly edited local_settings.py file in the develop-aplus repository. Stopped the memcached container momentarily with `docker stop aplus-memcached-1` to simulate being unable to access the cache container, and restarted it with `docker start aplus-memcached-1`, and looked at logs / UI to verify the build succeeded after initial cache failures.

Had to tweak some things to get the gitmanager container + cache to work, including building own run-gitmanager image (just installs pymemcache) and generating ssh keys (gitmanager container failed to start otherwise) as well as mounting my own local_settings.py file (otherwise the one in run-gitmanager container gets used).

docker-compose.yml
```
volumes:
  data:

services:
  plus:
    image: apluslms/run-aplus-front
    command: "python3 -m debugpy --listen 0.0.0.0:5677 manage.py runserver 0.0.0.0:8000"
    environment:
      APLUS_ENABLE_DJANGO_DEBUG_TOOLBAR: 'false'
      USE_GITMANAGER: 'true'
    volumes:
      - data:/data
      - ./a-plus/:/srv/aplus/:ro
    ports:
      - "8000:8000"
      - "5677:5677"
    depends_on:
      - grader
      - gitmanager
  grader:
    image: apluslms/run-mooc-grader
    command: "python3 -m debugpy --listen 0.0.0.0:5676 manage.py runserver 0.0.0.0:8080"
    volumes:
      - data:/data
      - /var/run/docker.sock:/var/run/docker.sock
      - /tmp/aplus:/tmp/aplus
    ports:
      - "8080:8080"
      - "5676:5676"
    depends_on:
      - gitmanager
  gitmanager:
    image: run-gitmanager
    command: "python3 -m debugpy --listen 0.0.0.0:5675 manage.py runserver 0.0.0.0:8070"
    environment:
      HUEY_IMMEDIATE: 'true'
      GITMANAGER_LOCAL_SETTINGS: '/srv/gitmanager/local_settings.py'
    volumes:
      - data:/data
      - /var/run/docker.sock:/var/run/docker.sock
      - /tmp/aplus:/tmp/aplus
      - ./gitmanager/:/srv/gitmanager/:ro
      - ./aplus-manual/:/srv/courses/source/default:ro
      - ./gitmanager/ssh/:/etc/gitmanager/ssh/:ro
    ports:
      - "8070:8070"
      - "5680:5678"
  memcached:
    image: memcached
```

local_settings.py
```
# rest of the file as is
...
CACHES = {
    'default': {
        'BACKEND': 'util.retrying_memcache_client.RetryingMemcacheClient',
        'LOCATION': 'memcached:11211',
        'TIMEOUT': None,
        'OPTIONS': {
            'retry_attempts': 1000,
            'retry_timeout': 1,
            'dead_timeout': 1,
        }
    }
}
...
```